### PR TITLE
fixes error: unresolved react mount module during webpack compilation

### DIFF
--- a/client/src/package.json
+++ b/client/src/package.json
@@ -6,6 +6,9 @@
     "build": "webpack",
     "start": "webpack-dev-server --hot --inline"
   },
+  "babel": {
+    "plugins": ["react-hot-loader/babel"]
+  },
   "keywords": [
     "serverless",
     "forum",
@@ -25,7 +28,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "file-loader": "^0.8.5",
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^3.0.0-beta.6",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.14.1"
   },

--- a/client/src/webpack.config.js
+++ b/client/src/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loaders: ["react-hot", 'babel?' + JSON.stringify(
+        loaders: ['babel?' + JSON.stringify(
           {
             presets: ['react', 'es2015'],
             "plugins": [


### PR DESCRIPTION
If you follow the Setup instructions in the README you will get a webpack compilation error RE: an unresolved react mount module.

This solution updates react-hot-loader to the latest version and implements the required config changes for the react-hot-loader 3.x branch.